### PR TITLE
Black screen fix on M1/2/3 macOs machines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ubuntu:20.04
+FROM --platform=linux/amd64 ubuntu:20.04
+#FROM ubuntu:20.04
 
 # Expose ports to taste
 # EXPOSE 80 8000 8080 443 5432 27017

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ FROM --platform=linux/amd64 ubuntu:20.04
 # Expose ports to taste
 # EXPOSE 80 8000 8080 443 5432 27017
 
+# Fix Quartz on macOS on Apple Silicon (M1/M2/M3)
+ENV _JAVA_OPTIONS="-Dsun.java2d.xrender=false"
+
 # Make sure we have the necessary command line tools
 # as well as some libraries that are mysteriously needed
 # in order for OpenJDK to work.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM --platform=linux/amd64 ubuntu:20.04
-#FROM ubuntu:20.04
 
 # Expose ports to taste
 # EXPOSE 80 8000 8080 443 5432 27017

--- a/abevjava.sh
+++ b/abevjava.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+ export _JAVA_OPTIONS='-Dsun.java2d.xrender=false’
 pushd /usr/share/abevjava;
 ./abevjava_start;
 popd

--- a/abevjava.sh
+++ b/abevjava.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
- export _JAVA_OPTIONS='-Dsun.java2d.xrender=false’
+
 pushd /usr/share/abevjava;
 ./abevjava_start;
 popd

--- a/install.sh
+++ b/install.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-
+export _JAVA_OPTIONS='-Dsun.java2d.xrender=false’
 java -jar /root/utils/abevjava_install.jar

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export _JAVA_OPTIONS='-Dsun.java2d.xrender=false’
-java -jar /root/utils/abevjava_install.jar && java -jar /root/utils/igazol.jar
+java -jar /root/utils/abevjava_install.jar
+java -jar /root/utils/igazol.jar


### PR DESCRIPTION
See https://github.com/XQuartz/XQuartz/issues/31#issuecomment-1781384572  for xquartz issue on M1 macs.
Setting platform to amd64 as xquartz fails to start otherwise.